### PR TITLE
use ~/.gitconfig email if no email provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Or, for multiple locations, use commas to delimit locations
 covgen <your_email_address> destination.md,newDirectory/second_destination.md
 ```
 
+If you don't specify an email address, it will use the email found in `~/.gitconfig`.
+
 Warning! Just copy and pasting a code of conduct isn't a fix. You have to live by it.
 
 I've made this project because the Contributor Covenant is a really good Code of Conduct to use as a standard and if you've read and will abide by it, it's a good default to include in your project.

--- a/cli.js
+++ b/cli.js
@@ -1,14 +1,32 @@
 #!/usr/bin/env node
 const fn = require('./')
+const { execSync } = require('child_process')
 
-if (process.argv.length < 3 || !process.argv.every(val => val.match(/(--help|-h)/) === null)) {
+function printHelp () {
   console.log('Usage: node ' + process.argv[1] + ' <email@address.domain> [destination]')
   console.log('Or:    covgen <email@address.domain> [destination] (if installed globally)')
-  process.exit(1)
 }
 
-if (process.argv[0] === 'covgen') {
-  fn(process.argv[1], process.argv[2])
-} else {
-  fn(process.argv[2], process.argv[3])
+if (!process.argv.every(val => val.match(/(--help|-h)/) === null)) {
+  printHelp()
+  process.exit(0)
 }
+
+if (process.argv[0] !== 'covgen') {
+  process.argv.shift()
+}
+
+let email = process.argv[1]
+const dest = process.argv[2]
+
+if (email === undefined) {
+  try {
+    email = execSync('git config --get user.email').toString().trim()
+    console.log('No email provided, using the email in your .gitconfig...')
+  } catch {
+    printHelp()
+    process.exit(1)
+  }
+}
+
+fn(email, dest)

--- a/covenant.js
+++ b/covenant.js
@@ -18,7 +18,7 @@ module.exports = async function download (email, dest) {
     throw new Error('An email address must be provided!')
   }
 
-  var url = 'https://www.contributor-covenant.org/version/2/0/code_of_conduct/code_of_conduct.md'
+  const url = 'https://www.contributor-covenant.org/version/2/0/code_of_conduct/code_of_conduct.md'
   dest = dest || 'CODE_OF_CONDUCT.md'
 
   console.log('Downloading Contributors Covenant...')
@@ -26,11 +26,11 @@ module.exports = async function download (email, dest) {
   const getString = bent('string')
   const coc = await getString(url)
   console.log('Replacing e-mail address...')
-  var content = coc.replace('[INSERT CONTACT METHOD]', email)
+  const content = coc.replace('[INSERT CONTACT METHOD]', email)
 
   if (dest.split(',').length > 1) {
-    let destinations = dest.split(',')
-    for (var i = 0; i < destinations.length; i++) {
+    const destinations = dest.split(',')
+    for (let i = 0; i < destinations.length; i++) {
       await writeFile(destinations[i], content)
     }
   } else {

--- a/test/fixtures/CODE_OF_CONDUCT.md
+++ b/test/fixtures/CODE_OF_CONDUCT.md
@@ -117,14 +117,18 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
+Community Impact Guidelines were inspired by 
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
 


### PR DESCRIPTION
hi!

this pr implements #20 (it also updates the test covenant file to be the same as the one being downloaded)